### PR TITLE
Prevent 3DS page's redirection to launch browser

### DIFF
--- a/android-sdk/src/main/java/com/everypay/sdk/PaymentBrowserActivity.java
+++ b/android-sdk/src/main/java/com/everypay/sdk/PaymentBrowserActivity.java
@@ -227,15 +227,8 @@ public class PaymentBrowserActivity extends AppCompatActivity {
 
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
-            log.d("shouldOverrideUrlLoading: " + url);
-            boolean isBrowserFlowEndUrl = isBrowserFlowEndUrl(url);
-            if (isBrowserFlowEndUrl) {
-                log.d("shouldOverrideUrlLoading (yes, payment end): " + url);
-                onBrowserFlowEnded(url);
-                return true;
-            }
-
-            return super.shouldOverrideUrlLoading(view, url);
+            view.loadUrl(url);
+            return false; // then it is not handled by default action
         }
 
         @Override


### PR DESCRIPTION
Currently when the 3ds page makes a redirection, the redirected link is started in the browser rather than the app's webview. The enduser makes a purchase but the flow gets broken.